### PR TITLE
better content management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@
 # rspec failure tracking
 .rspec_status
 
+*.gem
+
 *.swp

--- a/examples/debug/Supfile
+++ b/examples/debug/Supfile
@@ -8,10 +8,10 @@ add_pane do |pane|
   pane.title = "Time Update - Every Second"
 
   pane.interval = 1
-  pane.content do
-    [
-      `date`
-    ]
+  pane.content do |content|
+    date = `date`
+
+    content.add_row(date)
   end
 end
 
@@ -25,10 +25,10 @@ add_pane do |pane|
   pane.title = "Time Update - Every 5 Seconds"
 
   pane.interval = 5
-  pane.content do
-    [
-      `date`
-    ]
+  pane.content do |content|
+    date = `date`
+
+    content.add_row(date)
   end
 end
 
@@ -42,13 +42,31 @@ add_pane do |pane|
   pane.title = "Maybe Error - Every 10 Seconds"
 
   pane.interval = 10
-  pane.content do
+  pane.content do |content|
     if [true, false].sample
       raise "An error occured! Oh no!"
     end
 
-    [
-      "[fg=cyan]No error occured[fg=white]"
-    ]
+    output = "[fg=cyan]No error occured[fg=white]"
+
+    content.add_row(output)
+  end
+end
+
+add_pane do |pane|
+  pane.height = 0.25
+  pane.width = 0.35
+  pane.top = 0.25
+  pane.left = 0.25
+
+  pane.highlight = false
+  pane.title = "Multiple Contents"
+
+  pane.interval = 10
+  pane.content do |content|
+    content.add_row("Line 1 of page 1", page: "Page 1")
+    content.add_row("Line 2 of page 1", page: "Page 1")
+    content.add_row("Line 1 of page 2", page: "Page 2")
+    content.add_row("Line 2 of page 2", page: "Page 2")
   end
 end

--- a/examples/josh-fastlane/Supfile
+++ b/examples/josh-fastlane/Supfile
@@ -147,6 +147,9 @@ add_pane do |pane|
 
       ["#{number} (#{status}) by #{login} - #{message}", [item, workflow]]
     end
+
+    rescue
+      ["Failed to fetch for reason"]
   end
   pane.selection do |data|
     workflow = data[1]

--- a/examples/josh-fastlane/Supfile
+++ b/examples/josh-fastlane/Supfile
@@ -22,7 +22,7 @@ add_pane do |pane|
   pane.title = "Stats: fastlane-community"
 
   pane.interval = 1
-  pane.content do
+  pane.content do |builder|
     days_1 = 0
     days_7 = 0
     days_30 = 0
@@ -41,13 +41,11 @@ add_pane do |pane|
       days_365 +=1 if days <= 365
     end
 
-    [
-      "Opened today: #{days_1}",
-      "Opened 7 days: #{days_7}",
-      "Opened 30 days: #{days_30}",
-      "Opened 60 days: #{days_60}",
-      "Opened 365 days: #{days_365}"
-    ] 
+    builder.add_row("Opened today: #{days_1}")
+    builder.add_row("Opened 7 days: #{days_7}")
+    builder.add_row("Opened 30 days: #{days_30}")
+    builder.add_row("Opened 60 days: #{days_60}")
+    builder.add_row("Opened 365 days: #{days_365}")
   end
 end
 
@@ -65,7 +63,7 @@ add_pane do |pane|
   pane.title = "Stats: fastlane/fastlane"
 
   pane.interval = 1
-  pane.content do
+  pane.content do |builder|
     days_1 = 0
     days_7 = 0
     days_30 = 0
@@ -86,14 +84,12 @@ add_pane do |pane|
       days_60_plus +=1 if days > 60
     end
 
-    [
-      "Opened today: #{days_1}",
-      "Opened 7 days: #{days_7}",
-      "Opened 30 days: #{days_30}",
-      "Opened 45 days: #{days_45}",
-      "Opened 60 days: #{days_60}",
-      "More than 60 days: #{days_60_plus}",
-    ] 
+    builder.add_row("Opened today: #{days_1}")
+    builder.add_row("Opened 7 days: #{days_7}")
+    builder.add_row("Opened 30 days: #{days_30}")
+    builder.add_row("Opened 45 days: #{days_45}")
+    builder.add_row("Opened 60 days: #{days_60}")
+    builder.add_row("More than 60 days: #{days_60_plus}")
   end
 end
 
@@ -111,7 +107,7 @@ add_pane do |pane|
   pane.title = "Circle CI - fastlane/fastlane"
 
   pane.interval = 60 * 5
-  pane.content do 
+  pane.content do |builder|
     resp = RestClient::Request.execute(
       method: :get, 
       url: "https://circleci.com/api/v2/project/github/fastlane/fastlane/pipeline", 
@@ -145,11 +141,11 @@ add_pane do |pane|
         status = "[fg=yellow]#{status}[fg=white]"
       end
 
-      ["#{number} (#{status}) by #{login} - #{message}", [item, workflow]]
-    end
+      display = "#{number} (#{status}) by #{login} - #{message}"
+      object = [item, workflow]
 
-    rescue
-      ["Failed to fetch for reason"]
+      builder.add_row(display, object)
+    end
   end
   pane.selection do |data|
     workflow = data[1]
@@ -182,7 +178,7 @@ add_pane do |pane|
   pane.title = "Open PRs - fastlane-community"
 
   pane.interval = 60 * 5
-  pane.content do
+  pane.content do |builder|
     fastlane_community_prs = []
 
     resp = RestClient::Request.execute(
@@ -216,13 +212,9 @@ add_pane do |pane|
         days = (Time.now - date).to_i / (24 * 60 * 60)
         days_formatted = '%3.3s' % days.to_s
 
-        ["[fg=yellow]#{number_formatted}[fg=cyan] #{days_formatted}d ago[fg=white] #{title}",pr]
+        display = "[fg=yellow]#{number_formatted}[fg=cyan] #{days_formatted}d ago[fg=white] #{title}"
+        builder.add_row(display, pr, page: name)
       end
-
-      {
-        title: name,
-        content: prs
-      }
     end
   end
   pane.selection do |data|
@@ -246,7 +238,7 @@ add_pane do |pane|
   pane.title = "Open PRs - fastlane/fastlane"
 
   pane.interval = 60 * 5
-  pane.content do
+  pane.content do |builder|
     fastlane_prs = []
 
     resp = RestClient::Request.execute(
@@ -267,7 +259,8 @@ add_pane do |pane|
       days = (Time.now - date).to_i / (24 * 60 * 60)
       days_formatted = '%3.3s' % days.to_s
 
-      ["[fg=yellow]##{number}[fg=cyan] #{days_formatted}d ago[fg=white] #{title}",pr]
+      display = "[fg=yellow]##{number}[fg=cyan] #{days_formatted}d ago[fg=white] #{title}"
+      builder.add_row(display, pr)
     end
   end
   pane.selection do |data|

--- a/lib/wassup/pane_builder.rb
+++ b/lib/wassup/pane_builder.rb
@@ -15,12 +15,45 @@ module Wassup
     attr_accessor :selection_blocks
 
     class ContentBuilder
-      attr_accessor :clear
-      attr_accessor :content
+      attr_accessor :contents
 
-      def initialize()
-        @clear = false
-        @content = []
+      def initialize(contents)
+        @contents = contents
+        @need_to_clear = true
+      end
+
+      def clear=(clear)
+        @need_to_clear = clear
+      end
+
+      def add_row(display, object=nil, page:nil)
+        if @need_to_clear
+          @need_to_clear = false
+          self.contents = []
+        end
+
+        content = nil
+
+        # Create contents if none
+        if page.nil?
+          if self.contents.empty?
+            content = Pane::Content.new
+            self.contents << content
+          else
+            content = self.contents.first
+          end
+        elsif page.is_a?(String)
+          content = self.contents.find do |content|
+            content.title == page
+          end
+
+          if content.nil?
+            content = Pane::Content.new(page)
+            self.contents << content
+          end
+        end
+
+        content.add_row(display, object)
       end
     end
 

--- a/lib/wassup/pane_builder.rb
+++ b/lib/wassup/pane_builder.rb
@@ -14,6 +14,16 @@ module Wassup
     attr_accessor :content_block
     attr_accessor :selection_blocks
 
+    class ContentBuilder
+      attr_accessor :clear
+      attr_accessor :content
+
+      def initialize()
+        @clear = false
+        @content = []
+      end
+    end
+
     def initialize()
       @height = 1
       @weight = 1


### PR DESCRIPTION
## Motivation
Adding row (and pages) wasn't easily explainable because it was based on array or types. This also made the code very messy.

## Description
The `page.content` block in `Supfile` now has an argument passed into it which is a `ContentBuilder`
- `add_row("display string")`
- `add_row("display string", data_object_for_selection)`
- `add_row("display string", data_object_for_selection, page: "Title of page")`

## Example

### Single Page
```ruby
pane.content do |builder|
  builder.add_row("Line 1 of page 1")
  builder.add_row("Line 1 of page 2")
end
```

### Single Page
```ruby
pane.content do | builder|
  builder.add_row("Line 1 of page 1")
  builder.add_row("Line 1 of page 2")
end
```

### Single Page with data

```ruby
pane.content do | builder|
  builder.add_row("Line 1 of page 1", "some url")
  builder.add_row("Line 2 of page 1", "some url")
end
```