### PR TITLE
Improve refresh state

### DIFF
--- a/examples/debug/Supfile
+++ b/examples/debug/Supfile
@@ -24,7 +24,7 @@ add_pane do |pane|
   pane.highlight = false
   pane.title = "Time Update - Every 5 Seconds"
 
-  pane.interval = 5
+  pane.interval = 30
   pane.content do |content|
     date = `date`
 
@@ -68,5 +68,46 @@ add_pane do |pane|
     content.add_row("Line 2 of page 1", page: "Page 1")
     content.add_row("Line 1 of page 2", page: "Page 2")
     content.add_row("Line 2 of page 2", page: "Page 2")
+  end
+end
+
+add_pane do |pane|
+  pane.height = 0.25
+  pane.width = 0.6
+  pane.top = 0.5
+  pane.left = 0
+
+  pane.highlight = false
+  pane.title = "Time Update - Slow Reload"
+
+  pane.interval = 30
+  pane.show_refresh = true
+  pane.content do |content|
+    sleep 10
+
+    date = `date`
+
+    content.add_row(date)
+  end
+end
+
+require 'stringio'
+foo = StringIO.new
+$stdout = foo
+
+add_pane do |pane|
+  pane.height = 1
+  pane.width = 0.4
+  pane.top = 0.0
+  pane.left = 0.6
+
+  pane.highlight = false
+  pane.title = "STDOUT"
+
+  pane.interval = 4
+  pane.content do |content|
+    $stdout.string.split("\n").each do |line|
+      content.add_row(line)
+    end 
   end
 end

--- a/examples/josh-fastlane/Supfile
+++ b/examples/josh-fastlane/Supfile
@@ -21,7 +21,7 @@ add_pane do |pane|
 
   pane.title = "Stats: fastlane-community"
 
-  pane.interval = 10
+  pane.interval = 2
   pane.content do |builder|
     days_1 = 0
     days_7 = 0
@@ -62,7 +62,7 @@ add_pane do |pane|
 
   pane.title = "Stats: fastlane/fastlane"
 
-  pane.interval = 10
+  pane.interval = 2
   pane.content do |builder|
     days_1 = 0
     days_7 = 0
@@ -107,6 +107,7 @@ add_pane do |pane|
   pane.title = "Circle CI - fastlane/fastlane"
 
   pane.interval = 60 * 5
+  pane.show_refresh = true
   pane.content do |builder|
     resp = RestClient::Request.execute(
       method: :get, 
@@ -121,7 +122,7 @@ add_pane do |pane|
     end.map do |item|
       id = item["id"]
       number = item["number"]
-      message = item["vcs"]["commit"]["subject"]
+      message = (item["vcs"]["commit"] || {})["subject"]
       login = item["trigger"]["actor"]["login"]
 
       resp = RestClient::Request.execute(
@@ -178,6 +179,7 @@ add_pane do |pane|
   pane.title = "Open PRs - fastlane-community"
 
   pane.interval = 60 * 5
+  pane.show_refresh = true
   pane.content do |builder|
     fastlane_community_prs = []
 
@@ -238,6 +240,7 @@ add_pane do |pane|
   pane.title = "Open PRs - fastlane/fastlane"
 
   pane.interval = 60 * 5
+  pane.show_refresh = true
   pane.content do |builder|
     fastlane_prs = []
 

--- a/examples/josh-fastlane/Supfile
+++ b/examples/josh-fastlane/Supfile
@@ -22,6 +22,7 @@ add_pane do |pane|
   pane.title = "Stats: fastlane-community"
 
   pane.interval = 2
+  pane.show_refresh = false
   pane.content do |builder|
     days_1 = 0
     days_7 = 0
@@ -63,6 +64,7 @@ add_pane do |pane|
   pane.title = "Stats: fastlane/fastlane"
 
   pane.interval = 2
+  pane.show_refresh = false
   pane.content do |builder|
     days_1 = 0
     days_7 = 0

--- a/examples/josh-fastlane/Supfile
+++ b/examples/josh-fastlane/Supfile
@@ -21,7 +21,7 @@ add_pane do |pane|
 
   pane.title = "Stats: fastlane-community"
 
-  pane.interval = 1
+  pane.interval = 10
   pane.content do |builder|
     days_1 = 0
     days_7 = 0
@@ -62,7 +62,7 @@ add_pane do |pane|
 
   pane.title = "Stats: fastlane/fastlane"
 
-  pane.interval = 1
+  pane.interval = 10
   pane.content do |builder|
     days_1 = 0
     days_7 = 0

--- a/lib/wassup/app.rb
+++ b/lib/wassup/app.rb
@@ -34,6 +34,7 @@ module Wassup
         highlight: pane_builder.highlight, 
         focus_number: number,
         interval: pane_builder.interval,
+        show_refresh: pane_builder.show_refresh,
         content_block: pane_builder.content_block,
         selection_blocks: pane_builder.selection_blocks
       )
@@ -74,7 +75,7 @@ module Wassup
 
       begin
 
-        @hidden_pane = Pane.new(0, 0, 0, 0, highlight: false, focus_number: 0, interval: nil, content_block: nil, selection_blocks: nil)
+        @hidden_pane = Pane.new(0, 0, 0, 0, highlight: false, focus_number: 0, interval: nil, show_refresh: false, content_block: nil, selection_blocks: nil)
         @hidden_pane.focus_handler = @focus_handler
         @focused_pane = @hidden_pane
 

--- a/lib/wassup/pane.rb
+++ b/lib/wassup/pane.rb
@@ -153,6 +153,10 @@ module Wassup
 			end
 		end
 
+		def refreshing?
+			return !self.content_thread.nil?
+		end
+
     def refresh(force: false)
       return if !needs_refresh? && !force
 
@@ -176,6 +180,10 @@ module Wassup
           elsif rtn.is_a?(Wassup::PaneBuilder::ContentBuilder)
             self.refresh_content(rtn.contents)
           end
+
+					self.content_thread = nil
+					self.update_box
+					self.update_title
         else
           # This shouldn't happen
           # TODO: also fix this
@@ -193,6 +201,8 @@ module Wassup
             next Ope.new(ex)
           end
         }
+				self.update_box
+				self.update_title
       end
     end
 
@@ -224,6 +234,10 @@ module Wassup
 
       title = self.title || "<No Title>"
       full_title = "#{self.focus_number} - #{title}"
+
+			if self.refreshing?
+				full_title += " (Refreshing)"
+			end
 
       self.win.setpos(0, 3)
       self.win.addstr(full_title)

--- a/lib/wassup/pane_builder.rb
+++ b/lib/wassup/pane_builder.rb
@@ -22,7 +22,7 @@ module Wassup
       def initialize(contents)
         @contents = contents
         @need_to_clear = true
-        @show_refresh = false
+        @show_refresh = true
       end
 
       def clear=(clear)

--- a/lib/wassup/pane_builder.rb
+++ b/lib/wassup/pane_builder.rb
@@ -10,6 +10,8 @@ module Wassup
 
     attr_accessor :title
 
+    attr_accessor :show_refresh
+
     attr_accessor :interval
     attr_accessor :content_block
     attr_accessor :selection_blocks
@@ -20,6 +22,7 @@ module Wassup
       def initialize(contents)
         @contents = contents
         @need_to_clear = true
+        @show_refresh = false
       end
 
       def clear=(clear)


### PR DESCRIPTION
## Motivation
There was no indication that refresh was happening which made the UI feel a bit weird

## Description
- Now shows a ticking motion next to the title on the left when refreshing
- Will only show if `pane.show_refresh = true` is set (defaults to true and can be turned off with false)

## Example
```rb
add_pane do |pane|
  pane.show_refresh = true
  pane.content do |builder|
    sleep 5
    builder.add_row("Stuff")
  end
end
```


https://user-images.githubusercontent.com/401294/145518525-b1e74704-36a2-4414-ae20-9154fb12c703.mov

