### PR TITLE
Add GitHub API rate limiter with search API support

### DIFF
--- a/bin/wassup
+++ b/bin/wassup
@@ -6,7 +6,7 @@ debug = ARGV.delete("--debug")
 path = ARGV[0] || 'Supfile'
 port = ARGV[1] || 0
 
-unless File.exists?(path)
+unless File.exist?(path)
   raise "Missing file: #{path}"
 end
 

--- a/examples/github_api_demo.rb
+++ b/examples/github_api_demo.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/wassup/helpers/github'
+
+# Example demonstrating how to use the new GitHub API method
+# to replace manual RestClient requests with rate-limited API calls
+
+# Instead of manual RestClient calls like:
+# resp = RestClient::Request.execute(
+#   method: :get, 
+#   url: "https://api.github.com/repos/owner/repo/pulls/123", 
+#   user: ENV["WASSUP_GITHUB_USERNAME"],
+#   password: ENV["WASSUP_GITHUB_ACCESS_TOKEN"]
+# )
+# pr = JSON.parse(resp)
+
+# Use the new GitHub API method:
+org = "your-org"
+repo = "your-repo"
+pr_number = 123
+
+# Get PR data
+pr = Wassup::Helpers::GitHub.api(path: "/repos/#{org}/#{repo}/pulls/#{pr_number}")
+
+puts "PR: #{pr['title']}"
+puts "Draft: #{pr['draft']}"
+puts "Requested reviewers: #{pr['requested_reviewers'].size}"
+puts "Requested teams: #{pr['requested_teams'].size}"
+
+# Get PR reviews
+reviews = Wassup::Helpers::GitHub.api(path: "/repos/#{org}/#{repo}/pulls/#{pr_number}/reviews")
+
+# Filter out your own reviews
+reviews = reviews.select { |review| review["user"]["login"] != "your-username" }
+
+approved = reviews.count { |review| review["state"] == "APPROVED" }
+changes_requested = reviews.count { |review| review["state"] == "CHANGES_REQUESTED" }
+
+puts "Approved: #{approved}"
+puts "Changes requested: #{changes_requested}"
+
+# Get check runs for the PR's head commit
+head_sha = pr["head"]["sha"]
+check_runs = Wassup::Helpers::GitHub.api(path: "/repos/#{org}/#{repo}/commits/#{head_sha}/check-runs")
+
+puts "Check runs: #{check_runs['check_runs'].size}"
+
+# Get commit statuses
+statuses = Wassup::Helpers::GitHub.api(path: "/repos/#{org}/#{repo}/commits/#{head_sha}/statuses")
+
+puts "Statuses: #{statuses.size}"
+
+# Count different status types
+success_count = statuses.count { |status| status["state"] == "success" }
+failure_count = statuses.count { |status| status["state"] == "failure" }
+
+puts "Success: #{success_count}, Failures: #{failure_count}"
+
+# Example with query parameters
+# Get PRs with specific state
+open_prs = Wassup::Helpers::GitHub.api(
+  path: "/repos/#{org}/#{repo}/pulls", 
+  params: { state: "open", per_page: 10 }
+)
+
+puts "Open PRs: #{open_prs.size}"
+
+# Example with POST request (creating an issue comment)
+# comment_body = { body: "This is a test comment" }
+# new_comment = Wassup::Helpers::GitHub.api(
+#   path: "/repos/#{org}/#{repo}/issues/#{pr_number}/comments",
+#   method: :post,
+#   body: comment_body
+# )

--- a/examples/rate_limiter_demo.rb
+++ b/examples/rate_limiter_demo.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Demo script to show how the rate limiter handles burst requests
+
+require_relative '../lib/wassup/helpers/github_rate_limiter'
+
+# Mock the RestClient for demo purposes
+class MockRestClient
+  def self.execute(**args)
+    # Simulate API response time
+    sleep(0.05)
+    
+    # Create a mock response with rate limit headers
+    response = OpenStruct.new(
+      body: '{"items": []}',
+      headers: {
+        x_ratelimit_remaining: rand(100..4999),
+        x_ratelimit_reset: (Time.now + 3600).to_i,
+        x_ratelimit_limit: 5000
+      }
+    )
+    
+    puts "Request processed: #{args[:url]} (remaining: #{response.headers[:x_ratelimit_remaining]})"
+    response.body
+  end
+end
+
+# Replace RestClient with our mock
+module RestClient
+  Request = MockRestClient
+end
+
+# Test burst handling
+puts "Testing Rate Limiter with Burst Requests"
+puts "=" * 50
+
+rate_limiter = Wassup::Helpers::GitHub::RateLimiter.instance
+
+# Send 20 requests simultaneously
+puts "\nSending 20 requests simultaneously..."
+start_time = Time.now
+
+threads = []
+20.times do |i|
+  threads << Thread.new do
+    begin
+      rate_limiter.execute_request(
+        method: :get,
+        url: "https://api.github.com/test/#{i}"
+      )
+      puts "Request #{i+1} completed"
+    rescue => e
+      puts "Request #{i+1} failed: #{e.message}"
+    end
+  end
+end
+
+# Wait for all requests to complete
+threads.each(&:join)
+
+end_time = Time.now
+puts "\nAll requests completed in #{(end_time - start_time).round(2)} seconds"
+
+# Show final status
+puts "\nFinal Rate Limiter Status:"
+puts rate_limiter.status
+
+# Cleanup
+rate_limiter.stop_worker

--- a/lib/wassup/helpers/github_rate_limiter.rb
+++ b/lib/wassup/helpers/github_rate_limiter.rb
@@ -1,0 +1,380 @@
+module Wassup
+  module Helpers
+    module GitHub
+      class RateLimiter
+        require 'json'
+        require 'rest-client'
+        require 'thread'
+        require 'timeout'
+
+        attr_reader :remaining, :reset_at, :limit, :queue_size
+
+        def initialize
+          @mutex = Mutex.new
+          @queue = []
+          @remaining = nil
+          @reset_at = nil
+          @limit = nil
+          @search_remaining = nil
+          @search_reset_at = nil
+          @search_limit = nil
+          @last_request_time = nil
+          @worker_threads = []
+          @running = false
+          @max_queue_size = 20
+          @max_concurrent_requests = 5
+          @min_delay_between_requests = 1 # seconds
+          @min_delay_between_search_requests = 5 # seconds (12 requests/minute to avoid abuse detection)
+          @last_search_request_time = nil
+          @current_requests = []
+          @last_completed_request = nil
+          @last_error = nil
+        end
+
+        def start_worker
+          return if @running
+          
+          @running = true
+          @max_concurrent_requests.times do |i|
+            @worker_threads << Thread.new do
+              process_queue
+            end
+          end
+        end
+
+        def stop_worker
+          @running = false
+          @worker_threads.each(&:join)
+          @worker_threads.clear
+        end
+
+        def execute_request(method:, url:, **options)
+          future = RequestFuture.new
+          
+          @mutex.synchronize do
+            # Reject requests if queue is too large
+            if @queue.size >= @max_queue_size
+              future.set_error(StandardError.new("Rate limiter queue is full (#{@max_queue_size} requests). Please try again later."))
+              return future.get
+            end
+            
+            @queue << {
+              future: future,
+              method: method,
+              url: url,
+              options: options,
+              queued_at: Time.now
+            }
+          end
+
+          start_worker
+          
+          # Add timeout to prevent hanging
+          begin
+            Timeout.timeout(120) do
+              future.get
+            end
+          rescue Timeout::Error
+            queue_size = @mutex.synchronize { @queue.size }
+            raise StandardError.new("GitHub API request timed out after 120 seconds: #{method} #{url} (queue size: #{queue_size})")
+          end
+        end
+
+        def queue_size
+          @mutex.synchronize { @queue.size }
+        end
+
+        def status
+          @mutex.synchronize do
+            next_search_available = nil
+            if @last_search_request_time
+              next_search_time = @last_search_request_time + @min_delay_between_search_requests
+              next_search_available = [(next_search_time - Time.now).to_i, 0].max
+            end
+            
+            {
+              remaining: @remaining,
+              reset_at: @reset_at,
+              limit: @limit,
+              search_remaining: @search_remaining,
+              search_reset_at: @search_reset_at,
+              search_limit: @search_limit,
+              next_search_available: next_search_available,
+              queue_size: @queue.size,
+              running: @running,
+              worker_threads: @worker_threads.size,
+              current_requests: @current_requests.dup,
+              last_completed: @last_completed_request,
+              last_error: @last_error
+            }
+          end
+        end
+
+        private
+
+        def process_queue
+          while @running
+            request = nil
+            
+            @mutex.synchronize do
+              request = @queue.shift
+            end
+
+            if request
+              process_request(request)
+            else
+              sleep(0.1)
+            end
+          end
+        end
+
+        def process_request(request)
+          queue_time = Time.now - request[:queued_at]
+          request_start = Time.now
+          
+          # Track current request
+          @mutex.synchronize do
+            @current_requests << "#{request[:method]} #{request[:url]}"
+          end
+          
+          wait_if_needed
+          
+          begin
+            response = make_request(
+              method: request[:method],
+              url: request[:url],
+              **request[:options]
+            )
+            
+            request_time = Time.now - request_start
+            
+            update_rate_limit_from_response(response)
+            request[:future].set_result(response)
+            
+            # Track completed request
+            @mutex.synchronize do
+              @current_requests.delete("#{request[:method]} #{request[:url]}")
+              @last_completed_request = "#{request[:method]} #{request[:url]} (#{request_time.round(2)}s)"
+            end
+            
+            # Add minimum delay between requests to prevent overwhelming the API
+            sleep(@min_delay_between_requests)
+            
+          rescue RestClient::TooManyRequests => e
+            @mutex.synchronize do
+              @current_requests.delete("#{request[:method]} #{request[:url]}")
+              @last_error = "Rate limit exceeded: #{request[:method]} #{request[:url]}"
+            end
+            handle_rate_limit_exceeded(request, e)
+          rescue RestClient::Forbidden => e
+            @mutex.synchronize do
+              @current_requests.delete("#{request[:method]} #{request[:url]}")
+              @last_error = "Forbidden: #{request[:method]} #{request[:url]}"
+            end
+            handle_forbidden_error(request, e)
+          rescue => e
+            @mutex.synchronize do
+              @current_requests.delete("#{request[:method]} #{request[:url]}")
+              @last_error = "Error: #{e.message}"
+            end
+            request[:future].set_error(e)
+          end
+        end
+
+        def wait_if_needed
+          current_time = Time.now.to_i
+          
+          # Check if this is a search request and enforce minimum delay
+          if @last_search_request_time
+            time_since_last_search = Time.now - @last_search_request_time
+            if time_since_last_search < @min_delay_between_search_requests
+              sleep_time = @min_delay_between_search_requests - time_since_last_search
+              sleep(sleep_time) if sleep_time > 0
+            end
+          end
+          
+          # Check search API rate limit
+          if @search_remaining && @search_reset_at
+            if @search_remaining == 0 && current_time < @search_reset_at
+              sleep_time = @search_reset_at - current_time + 1
+              sleep(sleep_time) if sleep_time > 0
+              return
+            end
+            
+            # If search API is low, add extra delay
+            if @search_remaining < 5
+              sleep(3)
+              return
+            end
+          end
+          
+          # Check regular API rate limit
+          if @remaining && @reset_at
+            if @remaining == 0 && current_time < @reset_at
+              sleep_time = @reset_at - current_time + 1
+              sleep(sleep_time) if sleep_time > 0
+              return
+            end
+
+            # Calculate dynamic delay based on remaining requests and time
+            delay = calculate_dynamic_delay
+            sleep(delay) if delay > 0
+          end
+        end
+
+        def calculate_dynamic_delay
+          return 0 unless @remaining && @reset_at
+
+          current_time = Time.now.to_i
+          time_until_reset = [@reset_at - current_time, 0].max
+          
+          # If we have plenty of requests remaining, no delay needed
+          return 0 if @remaining > 50
+          
+          # If we're getting low on requests, add a small delay
+          if @remaining < 10
+            return 2.0
+          elsif @remaining < 25
+            return 1.0
+          else
+            return 0.5
+          end
+        end
+
+        def handle_rate_limit_exceeded(request, error)
+          # Check if the error response has retry-after header
+          retry_after = error.response&.headers&.[](:retry_after)
+          
+          if retry_after
+            sleep_time = retry_after.to_i + 1
+          elsif @reset_at
+            # Fallback to reset time or exponential backoff
+            sleep_time = [@reset_at - Time.now.to_i + 1, 60].max
+          else
+            # Default fallback when no reset time is available
+            sleep_time = 60
+          end
+
+          sleep(sleep_time)
+          
+          # Retry the request
+          @mutex.synchronize do
+            @queue.unshift(request)
+          end
+        end
+
+        def handle_forbidden_error(request, error)
+          # Check if this is rate limiting disguised as 403 (GitHub API inconsistency)
+          response_body = error.response&.body
+          if response_body&.include?("rate limit") || response_body&.include?("abuse")
+            # Treat as rate limit and retry
+            handle_rate_limit_exceeded(request, error)
+          else
+            # Genuine authentication/authorization error - don't retry
+            request[:future].set_error(error)
+          end
+        end
+
+        def make_request(method:, url:, **options)
+          @last_request_time = Time.now
+          
+          # Track search requests
+          if url.include?('/search/')
+            @last_search_request_time = Time.now
+          end
+
+          # Set default headers for GitHub API
+          headers = {
+            "Accept" => "application/vnd.github.v3+json",
+            "Content-Type" => "application/json"
+          }.merge(options[:headers] || {})
+
+          # Add authentication
+          auth_options = {
+            user: ENV["WASSUP_GITHUB_USERNAME"],
+            password: ENV["WASSUP_GITHUB_ACCESS_TOKEN"]
+          }
+
+          RestClient::Request.execute(
+            method: method,
+            url: url,
+            headers: headers,
+            **auth_options,
+            **options.except(:headers)
+          )
+        end
+
+        def update_rate_limit_from_response(response)
+          # Handle case where response is a string (from tests)
+          return unless response.respond_to?(:headers)
+          
+          headers = response.headers
+          
+          # Check for search API rate limit headers first
+          if headers[:x_ratelimit_resource] == 'search'
+            @search_remaining = headers[:x_ratelimit_remaining]&.to_i
+            @search_reset_at = headers[:x_ratelimit_reset]&.to_i
+            @search_limit = headers[:x_ratelimit_limit]&.to_i
+          else
+            # Regular API rate limit headers
+            @remaining = headers[:x_ratelimit_remaining]&.to_i
+            @reset_at = headers[:x_ratelimit_reset]&.to_i
+            @limit = headers[:x_ratelimit_limit]&.to_i
+          end
+        end
+
+        # Singleton instance
+        @instance = nil
+        @instance_mutex = Mutex.new
+
+        def self.instance
+          @instance_mutex.synchronize do
+            @instance ||= new
+          end
+        end
+
+        def self.execute_request(**args)
+          instance.execute_request(**args)
+        end
+
+        def self.status
+          instance.status
+        end
+      end
+
+      class RequestFuture
+        def initialize
+          @mutex = Mutex.new
+          @condition = ConditionVariable.new
+          @result = nil
+          @error = nil
+          @completed = false
+        end
+
+        def set_result(result)
+          @mutex.synchronize do
+            @result = result
+            @completed = true
+            @condition.signal
+          end
+        end
+
+        def set_error(error)
+          @mutex.synchronize do
+            @error = error
+            @completed = true
+            @condition.signal
+          end
+        end
+
+        def get
+          @mutex.synchronize do
+            @condition.wait(@mutex) until @completed
+            raise @error if @error
+            @result
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/wassup/helpers/github_spec.rb
+++ b/spec/wassup/helpers/github_spec.rb
@@ -22,17 +22,14 @@ RSpec.describe Wassup::Helpers::GitHub do
     end
 
     before do
-      allow(RestClient::Request).to receive(:execute).and_return(issues_response.to_json)
+      allow(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).and_return(issues_response.to_json)
       allow(JSON).to receive(:parse).and_return(issues_response)
     end
 
     it "searches for issues in an organization" do
-      expect(RestClient::Request).to receive(:execute).with(
+      expect(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).with(
         method: :get,
-        url: "https://api.github.com/search/issues?q=org:testorg",
-        user: "testuser",
-        password: "token123",
-        headers: { "Accept": "application/vnd.github.v3+json", "Content-Type": "application/json" }
+        url: "https://api.github.com/search/issues?q=org:testorg"
       )
 
       issues = Wassup::Helpers::GitHub.issues(org: "testorg")
@@ -40,24 +37,18 @@ RSpec.describe Wassup::Helpers::GitHub do
     end
 
     it "searches for issues in a specific repository" do
-      expect(RestClient::Request).to receive(:execute).with(
+      expect(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).with(
         method: :get,
-        url: "https://api.github.com/search/issues?q=repo:testorg/testrepo",
-        user: "testuser",
-        password: "token123",
-        headers: { "Accept": "application/vnd.github.v3+json", "Content-Type": "application/json" }
+        url: "https://api.github.com/search/issues?q=repo:testorg/testrepo"
       )
 
       Wassup::Helpers::GitHub.issues(org: "testorg", repo: "testrepo")
     end
 
     it "includes additional query parameters" do
-      expect(RestClient::Request).to receive(:execute).with(
+      expect(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).with(
         method: :get,
-        url: "https://api.github.com/search/issues?q=org:testorg is:open",
-        user: "testuser",
-        password: "token123",
-        headers: { "Accept": "application/vnd.github.v3+json", "Content-Type": "application/json" }
+        url: "https://api.github.com/search/issues?q=org:testorg is:open"
       )
 
       Wassup::Helpers::GitHub.issues(org: "testorg", q: "is:open")
@@ -73,16 +64,14 @@ RSpec.describe Wassup::Helpers::GitHub do
     end
 
     before do
-      allow(RestClient::Request).to receive(:execute).and_return(repos_response.to_json)
+      allow(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).and_return(repos_response.to_json)
       allow(JSON).to receive(:parse).and_return(repos_response)
     end
 
     it "fetches repositories for an organization" do
-      expect(RestClient::Request).to receive(:execute).with(
+      expect(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).with(
         method: :get,
-        url: "https://api.github.com/orgs/testorg/repos",
-        user: "testuser",
-        password: "token123"
+        url: "https://api.github.com/orgs/testorg/repos"
       )
 
       repos = Wassup::Helpers::GitHub.repos(org: "testorg")
@@ -107,19 +96,17 @@ RSpec.describe Wassup::Helpers::GitHub do
     end
 
     before do
-      allow(RestClient::Request).to receive(:execute).and_return(repos_response.to_json, pr_response.to_json, pr_response.to_json)
+      allow(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).and_return(repos_response.to_json, pr_response.to_json, pr_response.to_json)
       allow(JSON).to receive(:parse).and_return(repos_response, pr_response, pr_response)
     end
 
     it "fetches pull requests for a specific repository" do
-      allow(RestClient::Request).to receive(:execute).and_return(pr_response.to_json)
+      allow(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).and_return(pr_response.to_json)
       allow(JSON).to receive(:parse).and_return(pr_response)
       
-      expect(RestClient::Request).to receive(:execute).with(
+      expect(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).with(
         method: :get,
-        url: "https://api.github.com/repos/testorg/testrepo/pulls?per_page=100",
-        user: "testuser",
-        password: "token123"
+        url: "https://api.github.com/repos/testorg/testrepo/pulls?per_page=100"
       )
 
       prs = Wassup::Helpers::GitHub.pull_requests(org: "testorg", repo: "testrepo")
@@ -144,16 +131,14 @@ RSpec.describe Wassup::Helpers::GitHub do
     end
 
     before do
-      allow(RestClient::Request).to receive(:execute).and_return(releases_response.to_json)
+      allow(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).and_return(releases_response.to_json)
       allow(JSON).to receive(:parse).and_return(releases_response)
     end
 
     it "fetches releases for a repository" do
-      expect(RestClient::Request).to receive(:execute).with(
+      expect(Wassup::Helpers::GitHub::RateLimiter).to receive(:execute_request).with(
         method: :get,
-        url: "https://api.github.com/repos/testorg/testrepo/releases",
-        user: "testuser",
-        password: "token123"
+        url: "https://api.github.com/repos/testorg/testrepo/releases"
       )
 
       releases = Wassup::Helpers::GitHub.releases(org: "testorg", repo: "testrepo")


### PR DESCRIPTION
## Summary

- Add comprehensive rate limiter with queue management and worker threads for GitHub API requests
- Support separate rate limits for GitHub Search API (30/min) vs regular API (5000/hr) 
- Add generic `GitHub.api()` method for any GitHub API endpoint with rate limiting
- Implement proper error handling for 403 Forbidden vs 429 Too Many Requests
- Add minimum delays between requests to prevent GitHub's abuse detection
- Fix deprecation warning: `File.exists?` → `File.exist?`

## Key Features

### Rate Limiter
- Thread-safe queue with configurable worker threads
- Automatic rate limit detection from GitHub response headers
- Separate tracking for search API vs regular API limits
- Dynamic delays based on remaining rate limit
- Proper retry logic for rate limit exceeded errors

### Generic API Method
- `Helpers::GitHub.api(path:, method:, params:, body:)` for any GitHub endpoint
- Supports both full URLs and relative paths
- Automatic JSON parsing and error handling
- All requests go through the rate limiter

### Error Handling
- Distinguish between authentication errors (403) and rate limiting (429)
- Retry rate-limited requests with proper delays
- Handle GitHub's inconsistent 403 responses for rate limits

## Test Plan

- [x] Test rate limiter with multiple concurrent requests
- [x] Test search API rate limiting (30/min limit)
- [x] Test regular API rate limiting (5000/hr limit)
- [x] Test generic API method with various endpoints
- [x] Test error handling for 403 and 429 responses
- [x] Test queue management and worker threads
- [x] Verify existing functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)