### PR TITLE
Add world clock module with working hours color coding

### DIFF
--- a/docs/docs/panes/_category_.json
+++ b/docs/docs/panes/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Prebuilt Panes",
+  "position": 4,
+  "collapsible": true,
+  "collapsed": false
+}

--- a/docs/docs/panes/circleci.md
+++ b/docs/docs/panes/circleci.md
@@ -1,0 +1,209 @@
+# CircleCI Panes
+
+The CircleCI panes allow you to monitor your continuous integration workflows directly in your Wassup dashboard. Track build statuses, workflow progress, and pipeline health in real-time.
+
+## Prerequisites
+
+Before using CircleCI panes, you need to set up CircleCI authentication:
+
+1. Get your CircleCI API token from [CircleCI Personal API Tokens](https://app.circleci.com/settings/user/tokens)
+2. Set the environment variable:
+   ```bash
+   export CIRCLECI_API_TOKEN="your-token-here"
+   ```
+
+## Available CircleCI Panes
+
+### Workflows
+
+Display recent workflow runs for a specific repository.
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "CI Workflows"
+  pane.interval = 180  # Update every 3 minutes
+  
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "your-org",
+    repo: "your-repo"
+  )
+end
+```
+
+#### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `vcs` | String | Required | Version control system ("github" or "bitbucket") |
+| `org` | String | Required | Organization or username |
+| `repo` | String | Required | Repository name |
+
+#### Workflow Display Information
+
+The workflow pane shows:
+- **Status** - Success, failed, running, or other workflow states
+- **Branch** - The branch the workflow ran on
+- **Workflow Name** - The name of the CircleCI workflow
+- **Duration** - How long the workflow took to complete
+- **Triggered By** - Who or what triggered the workflow
+- **Timestamp** - When the workflow started
+
+#### Status Colors
+
+- 🟢 **Green** - Successful workflows
+- 🔴 **Red** - Failed workflows
+- 🟡 **Yellow** - Running workflows
+- ⚪ **Gray** - Other states (queued, canceled, etc.)
+
+#### Keyboard Controls
+
+- **Enter** - Open the selected workflow in CircleCI web interface
+
+## Example Configurations
+
+### Single Repository Monitoring
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Main App CI"
+  pane.interval = 120  # Update every 2 minutes
+  
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "your-company",
+    repo: "main-application"
+  )
+end
+```
+
+### Multiple Repository Dashboard
+
+```ruby
+# Frontend workflows
+add_pane do |pane|
+  pane.height = 0.33
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Frontend CI"
+  pane.interval = 180
+  
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "your-company",
+    repo: "frontend-app"
+  )
+end
+
+# Backend workflows
+add_pane do |pane|
+  pane.height = 0.33
+  pane.width = 1.0
+  pane.top = 0.33
+  pane.left = 0
+  
+  pane.title = "Backend CI"
+  pane.interval = 180
+  
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "your-company",
+    repo: "backend-api"
+  )
+end
+
+# Mobile workflows
+add_pane do |pane|
+  pane.height = 0.34
+  pane.width = 1.0
+  pane.top = 0.66
+  pane.left = 0
+  
+  pane.title = "Mobile CI"
+  pane.interval = 180
+  
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "your-company",
+    repo: "mobile-app"
+  )
+end
+```
+
+## Understanding Workflow Data
+
+### Workflow States
+
+CircleCI workflows can have several states:
+
+- **success** - All jobs completed successfully
+- **failed** - One or more jobs failed
+- **error** - Workflow encountered an error
+- **running** - Workflow is currently executing
+- **failing** - Workflow is running but has failed jobs
+- **on_hold** - Workflow is paused waiting for approval
+- **canceled** - Workflow was manually canceled
+- **unauthorized** - Insufficient permissions
+
+### Time Filtering
+
+The CircleCI pane shows workflows from the last 14 days by default. This helps keep the display relevant and improves performance.
+
+## Rate Limiting
+
+CircleCI API has rate limits:
+- 300 requests per minute for personal tokens
+- Higher limits for organization tokens
+
+The pane automatically handles rate limiting and will show appropriate messages when limits are reached.
+
+## Troubleshooting
+
+### Authentication Issues
+
+If you're getting authentication errors:
+
+1. Verify your CircleCI API token is set correctly:
+   ```bash
+   echo $CIRCLECI_API_TOKEN
+   ```
+2. Check that the token has the correct permissions
+3. Ensure the token hasn't expired
+
+### Repository Not Found
+
+If you get "repository not found" errors:
+
+1. Verify the VCS, organization, and repository names are correct
+2. Check that your token has access to the repository
+3. Ensure the repository is configured with CircleCI
+4. Verify the repository has at least one workflow run
+
+### Common Issues
+
+**No workflows showing:**
+- Check if the repository has any CircleCI workflows configured
+- Verify workflows have run in the last 14 days
+- Ensure the repository is properly connected to CircleCI
+
+**Slow updates:**
+- Consider increasing the interval for less critical repositories
+- Monitor your API usage to avoid rate limits
+
+**Permission errors:**
+- Verify your CircleCI token has access to the organization
+- Check if the repository is private and requires appropriate permissions
+
+For more troubleshooting help, check the [CircleCI Integration Documentation](../integrations/circleci/) or the [Common Issues Guide](../troubleshooting/common-issues.md).

--- a/docs/docs/panes/circleci.md
+++ b/docs/docs/panes/circleci.md
@@ -206,4 +206,4 @@ If you get "repository not found" errors:
 - Verify your CircleCI token has access to the organization
 - Check if the repository is private and requires appropriate permissions
 
-For more troubleshooting help, check the [CircleCI Integration Documentation](../integrations/circleci/) or the [Common Issues Guide](../troubleshooting/common-issues.md).
+For more troubleshooting help, check the [Common Issues Guide](../troubleshooting/common-issues.md).

--- a/docs/docs/panes/github.md
+++ b/docs/docs/panes/github.md
@@ -1,0 +1,209 @@
+# GitHub Panes
+
+The GitHub panes allow you to display GitHub repository information directly in your Wassup dashboard. These panes provide real-time updates on pull requests, releases, and search results.
+
+## Prerequisites
+
+Before using GitHub panes, you need to set up GitHub authentication. See the [GitHub Setup Guide](../integrations/github/setup.md) for detailed instructions.
+
+## Available GitHub Panes
+
+### Pull Requests
+
+Display pull requests for a specific repository.
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Pull Requests"
+  pane.interval = 300  # Update every 5 minutes
+  
+  pane.type = Wassup::Panes::GitHub::PullRequests.new(
+    org: "your-org",
+    repo: "your-repo",
+    show_username: true,
+    show_interactions: true
+  )
+end
+```
+
+#### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `org` | String | Required | GitHub organization or username |
+| `repo` | String | Required | Repository name |
+| `show_username` | Boolean | `false` | Show the username of the PR author |
+| `show_interactions` | Boolean | `false` | Show comment/review counts |
+
+#### Keyboard Controls
+
+- **Enter** - Open the selected pull request in your browser
+
+### Releases
+
+Display recent releases for a repository.
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0.5
+  
+  pane.title = "Releases"
+  pane.interval = 3600  # Update every hour
+  
+  pane.type = Wassup::Panes::GitHub::Releases.new(
+    org: "your-org",
+    repo: "your-repo"
+  )
+end
+```
+
+#### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `org` | String | Required | GitHub organization or username |
+| `repo` | String | Required | Repository name |
+
+#### Keyboard Controls
+
+- **Enter** - Open the selected release in your browser
+
+### Search
+
+Search for issues and pull requests across repositories.
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0.5
+  pane.left = 0
+  
+  pane.title = "My Issues"
+  pane.interval = 300  # Update every 5 minutes
+  
+  pane.type = Wassup::Panes::GitHub::Search.new(
+    org: "your-org",
+    repo: "your-repo",  # Optional - leave nil to search across org
+    query: "assignee:@me is:open",
+    show_repo: true,
+    show_username: false,
+    show_interactions: true
+  )
+end
+```
+
+#### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `org` | String | Required | GitHub organization or username |
+| `repo` | String | `nil` | Repository name (optional, searches across org if nil) |
+| `query` | String | Required | GitHub search query |
+| `show_repo` | Boolean | `true` | Show repository name in results |
+| `show_username` | Boolean | `false` | Show the username of the author |
+| `show_interactions` | Boolean | `false` | Show comment/review counts |
+
+#### Common Search Queries
+
+- `assignee:@me is:open` - Issues assigned to you
+- `author:@me is:open` - Issues/PRs created by you
+- `involves:@me is:open` - Issues/PRs involving you
+- `is:pr is:open review-requested:@me` - PRs requesting your review
+- `is:issue is:open label:bug` - Open bug issues
+- `is:pr is:open draft:false` - Non-draft pull requests
+
+#### Keyboard Controls
+
+- **Enter** - Open the selected issue/PR in your browser
+
+## Example Dashboard Layout
+
+```ruby
+# Top row - Pull requests and releases
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "PRs - Main Repo"
+  pane.interval = 300
+  
+  pane.type = Wassup::Panes::GitHub::PullRequests.new(
+    org: "your-org",
+    repo: "main-repo",
+    show_username: true,
+    show_interactions: true
+  )
+end
+
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0.5
+  
+  pane.title = "Recent Releases"
+  pane.interval = 3600
+  
+  pane.type = Wassup::Panes::GitHub::Releases.new(
+    org: "your-org",
+    repo: "main-repo"
+  )
+end
+
+# Bottom row - Search results
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0.5
+  pane.left = 0
+  
+  pane.title = "My Tasks"
+  pane.interval = 300
+  
+  pane.type = Wassup::Panes::GitHub::Search.new(
+    org: "your-org",
+    query: "assignee:@me is:open",
+    show_repo: true,
+    show_interactions: true
+  )
+end
+```
+
+## Rate Limiting
+
+GitHub API has rate limits. The GitHub panes automatically handle rate limiting and will show appropriate messages when limits are reached. Consider:
+
+- Using longer intervals for less critical panes
+- Monitoring your API usage in your GitHub settings
+- Using GitHub Apps for higher rate limits in organizations
+
+## Troubleshooting
+
+### Authentication Issues
+
+If you're getting authentication errors:
+
+1. Verify your GitHub token is set correctly
+2. Check token permissions include repository access
+3. Ensure the token hasn't expired
+
+### Repository Not Found
+
+If you get "repository not found" errors:
+
+1. Verify the organization and repository names are correct
+2. Check that your token has access to the repository
+3. Ensure the repository exists and is accessible
+
+For more troubleshooting tips, see the [GitHub Integration Guide](../integrations/github/setup.md).

--- a/docs/docs/panes/netlify.md
+++ b/docs/docs/panes/netlify.md
@@ -1,0 +1,251 @@
+# Netlify Panes
+
+The Netlify panes allow you to monitor your site deployments directly in your Wassup dashboard. Track deployment statuses, preview builds, and site health in real-time.
+
+## Prerequisites
+
+Before using Netlify panes, you need to set up Netlify authentication:
+
+1. Get your Netlify API token from [Netlify User Settings](https://app.netlify.com/user/applications#personal-access-tokens)
+2. Set the environment variable:
+   ```bash
+   export NETLIFY_API_TOKEN="your-token-here"
+   ```
+
+## Available Netlify Panes
+
+### Deploys
+
+Display recent deployments for a specific Netlify site.
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Site Deployments"
+  pane.interval = 300  # Update every 5 minutes
+  
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "your-site-id"
+  )
+end
+```
+
+#### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `site_id` | String | Required | Netlify site ID (found in site settings) |
+
+#### Finding Your Site ID
+
+You can find your site ID in several ways:
+
+1. **Netlify Dashboard**: Go to your site settings → General → Site details
+2. **URL**: It's in the URL when viewing your site (e.g., `https://app.netlify.com/sites/your-site-id/`)
+3. **API**: Use the Netlify API to list your sites
+
+#### Deployment Display Information
+
+The deploys pane shows:
+- **Status** - Build status (success, building, error, etc.)
+- **Branch** - The branch that was deployed
+- **Commit** - Short commit hash and message
+- **Deploy Time** - When the deployment was created
+- **Build Duration** - How long the build took
+- **Deploy URL** - The deployment URL (for previews)
+
+#### Status Colors
+
+- 🟢 **Green** - Successful deployments
+- 🔴 **Red** - Failed deployments  
+- 🟡 **Yellow** - Building/processing deployments
+- 🔵 **Blue** - Ready deployments
+- ⚪ **Gray** - Other states (queued, canceled, etc.)
+
+#### Keyboard Controls
+
+- **Enter** - Open the selected deployment in Netlify admin interface
+- **o** - Open the deployment preview URL in your browser
+
+## Example Configurations
+
+### Single Site Monitoring
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Production Site"
+  pane.interval = 180  # Update every 3 minutes
+  
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "abc123def-456g-789h-ijkl-mnop123qrstu"
+  )
+end
+```
+
+### Multiple Sites Dashboard
+
+```ruby
+# Production site
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Production"
+  pane.interval = 180
+  
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "prod-site-id"
+  )
+end
+
+# Staging site
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0.5
+  
+  pane.title = "Staging"
+  pane.interval = 120
+  
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "staging-site-id"
+  )
+end
+
+# Documentation site
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0.5
+  pane.left = 0
+  
+  pane.title = "Documentation"
+  pane.interval = 300
+  
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "docs-site-id"
+  )
+end
+```
+
+## Understanding Deployment Data
+
+### Deployment States
+
+Netlify deployments can have several states:
+
+- **ready** - Deployment is live and accessible
+- **building** - Currently building the site
+- **error** - Build failed due to an error
+- **processing** - Processing the built site
+- **enqueued** - Waiting in the build queue
+- **canceled** - Build was canceled
+- **skipped** - Build was skipped (no changes)
+
+### Deploy Types
+
+- **Production Deploy** - Deploys to your main site URL
+- **Deploy Preview** - Preview deploys for pull requests
+- **Branch Deploy** - Deploys from specific branches
+
+### Build Information
+
+Each deployment shows:
+- **Commit Information** - Hash, message, and author
+- **Build Duration** - Time taken for the build process
+- **Framework Detection** - Automatically detected framework
+- **Build Command** - The command used to build the site
+
+## Rate Limiting
+
+Netlify API has rate limits:
+- 500 requests per minute for personal tokens
+- 1000 requests per minute for team tokens
+
+The pane automatically handles rate limiting and will show appropriate messages when limits are reached.
+
+## Troubleshooting
+
+### Authentication Issues
+
+If you're getting authentication errors:
+
+1. Verify your Netlify API token is set correctly:
+   ```bash
+   echo $NETLIFY_API_TOKEN
+   ```
+2. Check that the token has the correct permissions
+3. Ensure the token hasn't expired or been revoked
+
+### Site Not Found
+
+If you get "site not found" errors:
+
+1. Verify the site ID is correct
+2. Check that your token has access to the site
+3. Ensure the site exists and is accessible to your account
+
+### Common Issues
+
+**No deployments showing:**
+- Check if the site has any recent deployments
+- Verify the site is properly configured in Netlify
+- Ensure you have the correct site ID
+
+**Slow updates:**
+- Consider increasing the interval for less critical sites
+- Monitor your API usage to avoid rate limits
+
+**Permission errors:**
+- Verify your Netlify token has access to the site
+- Check if the site is part of a team you don't have access to
+
+**Preview URLs not working:**
+- Some deployments may not have preview URLs (production deploys)
+- Check the deployment state - failed deployments won't have preview URLs
+- Verify the site has preview deploys enabled
+
+## Advanced Usage
+
+### Monitoring Multiple Environments
+
+You can create a comprehensive deployment monitoring setup:
+
+```ruby
+# Create a layout for different environments
+environments = [
+  { name: "Production", site_id: "prod-site-id", interval: 300 },
+  { name: "Staging", site_id: "staging-site-id", interval: 180 },
+  { name: "Development", site_id: "dev-site-id", interval: 120 }
+]
+
+environments.each_with_index do |env, index|
+  add_pane do |pane|
+    pane.height = 1.0 / environments.length
+    pane.width = 1.0
+    pane.top = index * (1.0 / environments.length)
+    pane.left = 0
+    
+    pane.title = "#{env[:name]} Deploys"
+    pane.interval = env[:interval]
+    
+    pane.type = Wassup::Panes::Netlify::Deploys.new(
+      site_id: env[:site_id]
+    )
+  end
+end
+```
+
+For more information about Netlify integration, see the [Netlify Setup Guide](../integrations/netlify/setup.md) or check the [Common Issues Guide](../troubleshooting/common-issues.md).

--- a/docs/docs/panes/overview.md
+++ b/docs/docs/panes/overview.md
@@ -1,0 +1,344 @@
+# Prebuilt Panes Overview
+
+Wassup comes with several prebuilt panes that integrate with popular development tools and services. These panes provide real-time information and allow you to interact with external services directly from your dashboard.
+
+## Available Panes
+
+### [GitHub](./github.md)
+Monitor your GitHub repositories with real-time updates on pull requests, releases, and issues.
+
+**Features:**
+- Pull requests with review status
+- Recent releases and tags
+- Issue and PR search across repositories
+- Direct browser integration
+
+**Use Cases:**
+- Code review monitoring
+- Release tracking
+- Issue management
+- Team collaboration
+
+### [CircleCI](./circleci.md)
+Track your continuous integration workflows and build statuses.
+
+**Features:**
+- Workflow status monitoring
+- Build duration tracking
+- Branch-specific CI results
+- Direct CircleCI integration
+
+**Use Cases:**
+- CI/CD monitoring
+- Build failure alerts
+- Deployment tracking
+- Development workflow oversight
+
+### [Netlify](./netlify.md)
+Monitor your site deployments and build statuses.
+
+**Features:**
+- Deployment status tracking
+- Build logs and errors
+- Preview URL access
+- Multi-site monitoring
+
+**Use Cases:**
+- Site deployment monitoring
+- Build failure detection
+- Preview environment management
+- Static site workflow tracking
+
+### [Shortcut](./shortcut.md)
+Manage your project stories and track team progress.
+
+**Features:**
+- Story status monitoring
+- Custom search queries
+- Multi-page story views
+- Story interaction
+
+**Use Cases:**
+- Sprint planning
+- Story tracking
+- Team progress monitoring
+- Project management
+
+### [World Clock](./world-clock.md)
+Display multiple time zones with working hours color coding.
+
+**Features:**
+- Multiple timezone support
+- Working hours visualization
+- Flexible time/date formatting
+- Smart DST handling
+
+**Use Cases:**
+- Distributed team coordination
+- Meeting scheduling
+- Global office hours
+- Client timezone awareness
+
+## Quick Start
+
+### 1. Choose Your Panes
+
+Select the panes that match your workflow:
+
+```ruby
+# Developer workflow
+add_pane do |pane|
+  pane.title = "Pull Requests"
+  pane.type = Wassup::Panes::GitHub::PullRequests.new(
+    org: "your-org",
+    repo: "your-repo"
+  )
+end
+
+add_pane do |pane|
+  pane.title = "CI Status"
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "your-org",
+    repo: "your-repo"
+  )
+end
+```
+
+### 2. Set Up Authentication
+
+Most panes require API tokens:
+
+```bash
+# GitHub
+export GITHUB_TOKEN="your-github-token"
+
+# CircleCI
+export CIRCLECI_API_TOKEN="your-circleci-token"
+
+# Netlify
+export NETLIFY_API_TOKEN="your-netlify-token"
+
+# Shortcut
+export SHORTCUT_API_TOKEN="your-shortcut-token"
+```
+
+### 3. Configure Your Layout
+
+Arrange panes to fit your screen and workflow:
+
+```ruby
+# Top row - Development
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0
+  pane.title = "PRs"
+  pane.type = Wassup::Panes::GitHub::PullRequests.new(...)
+end
+
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0.5
+  pane.title = "Deployments"
+  pane.type = Wassup::Panes::Netlify::Deploys.new(...)
+end
+
+# Bottom row - Project Management
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0.5
+  pane.left = 0
+  pane.title = "Stories"
+  pane.type = Wassup::Panes::Shortcut::Stories.new(...)
+end
+
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0.5
+  pane.left = 0.5
+  pane.title = "Team Times"
+  pane.type = Wassup::Panes::WorldClock.new(...)
+end
+```
+
+## Common Patterns
+
+### Development Dashboard
+
+Focus on code review and deployment monitoring:
+
+```ruby
+# Code review
+add_pane do |pane|
+  pane.title = "My PRs"
+  pane.type = Wassup::Panes::GitHub::Search.new(
+    org: "company",
+    query: "author:@me is:open"
+  )
+end
+
+# CI/CD status
+add_pane do |pane|
+  pane.title = "Build Status"
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "company",
+    repo: "main-app"
+  )
+end
+
+# Deployment status
+add_pane do |pane|
+  pane.title = "Live Site"
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "production-site-id"
+  )
+end
+```
+
+### Project Management Dashboard
+
+Focus on story tracking and team coordination:
+
+```ruby
+# Personal stories
+add_pane do |pane|
+  pane.title = "My Stories"
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "owner:@me !is:done"
+  )
+end
+
+# Team progress
+add_pane do |pane|
+  pane.title = "Sprint Progress"
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "iteration:current"
+  )
+end
+
+# Team availability
+add_pane do |pane|
+  pane.title = "Team Times"
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "Alice (SF)" => "America/Los_Angeles",
+      "Bob (NYC)" => "America/New_York",
+      "Carol (London)" => "Europe/London"
+    },
+    working_hours: {start: 9, end: 17},
+    color_coding: true
+  )
+end
+```
+
+### Operations Dashboard
+
+Focus on system health and deployments:
+
+```ruby
+# Production deployments
+add_pane do |pane|
+  pane.title = "Production"
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "prod-site-id"
+  )
+end
+
+# Staging deployments
+add_pane do |pane|
+  pane.title = "Staging"
+  pane.type = Wassup::Panes::Netlify::Deploys.new(
+    site_id: "staging-site-id"
+  )
+end
+
+# CI health
+add_pane do |pane|
+  pane.title = "CI Status"
+  pane.type = Wassup::Panes::CircleCI::Workflows.new(
+    vcs: "github",
+    org: "company",
+    repo: "main-app"
+  )
+end
+
+# Incident tracking
+add_pane do |pane|
+  pane.title = "Incidents"
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "label:incident !is:done"
+  )
+end
+```
+
+## Best Practices
+
+### Refresh Intervals
+
+Set appropriate refresh intervals based on importance:
+
+```ruby
+# Critical information - frequent updates
+pane.interval = 60   # 1 minute
+
+# Important information - moderate updates
+pane.interval = 300  # 5 minutes
+
+# Reference information - infrequent updates
+pane.interval = 900  # 15 minutes
+```
+
+### API Rate Limits
+
+Be mindful of API rate limits:
+
+- **GitHub**: 5,000 requests per hour
+- **CircleCI**: 300 requests per minute
+- **Netlify**: 500 requests per minute
+- **Shortcut**: 200 requests per minute
+
+### Error Handling
+
+All panes include built-in error handling:
+
+- Network connectivity issues
+- API rate limit exceeded
+- Authentication failures
+- Invalid configurations
+
+Errors are displayed in the pane with helpful messages and retry logic.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors**
+   - Verify API tokens are set correctly
+   - Check token permissions
+   - Ensure tokens haven't expired
+
+2. **No Data Showing**
+   - Verify service configuration
+   - Check API connectivity
+   - Review query parameters
+
+3. **Performance Issues**
+   - Increase refresh intervals
+   - Reduce number of simultaneous panes
+   - Monitor API usage
+
+### Getting Help
+
+- Check individual pane documentation for specific issues
+- Review the [Common Issues Guide](../troubleshooting/common-issues.md)
+- Verify service API status pages
+- Test configurations in service web interfaces first
+
+For more detailed information, see the individual pane documentation pages.

--- a/docs/docs/panes/shortcut.md
+++ b/docs/docs/panes/shortcut.md
@@ -1,0 +1,374 @@
+# Shortcut Panes
+
+The Shortcut panes allow you to monitor your project management stories directly in your Wassup dashboard. Track story progress, assignments, and team workflow in real-time.
+
+## Prerequisites
+
+Before using Shortcut panes, you need to set up Shortcut authentication:
+
+1. Get your Shortcut API token from [Shortcut Settings](https://app.shortcut.com/settings/api/tokens)
+2. Set the environment variable:
+   ```bash
+   export SHORTCUT_API_TOKEN="your-token-here"
+   ```
+
+## Available Shortcut Panes
+
+### Stories
+
+Display stories based on search queries. This is the primary pane for monitoring Shortcut stories.
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "My Stories"
+  pane.interval = 300  # Update every 5 minutes
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "owner:me !is:done"
+  )
+end
+```
+
+#### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `query` | String | Required | Shortcut search query |
+| `query_pages` | Hash | `nil` | Multiple queries with page names |
+
+#### Using Multiple Query Pages
+
+You can display multiple search results in different pages within the same pane:
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Team Stories"
+  pane.interval = 300
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query_pages: {
+      "My Stories" => "owner:me !is:done",
+      "In Review" => "state:\"In Review\"",
+      "Blocked" => "label:blocked !is:done",
+      "This Week" => "created:>-7d"
+    }
+  )
+end
+```
+
+#### Story Display Information
+
+The stories pane shows:
+- **Story ID** - Unique identifier (e.g., sc-1234)
+- **Story Name** - Title of the story
+- **Story Type** - Feature, bug, chore, etc.
+- **State** - Current workflow state
+- **Owner** - Assigned team member
+- **Labels** - Associated labels
+- **Points** - Story points estimate
+
+#### Keyboard Controls
+
+- **Enter** - Open the selected story in Shortcut web interface
+- **h/l** - Navigate between query pages (if multiple pages configured)
+
+## Common Search Queries
+
+### Personal Queries
+
+```ruby
+# Stories assigned to you
+"owner:me !is:done"
+
+# Stories you created
+"requester:me"
+
+# Stories you're following
+"follower:me"
+
+# Stories waiting for your review
+"owner:me state:\"In Review\""
+```
+
+### Team Queries
+
+```ruby
+# Stories in specific workflow state
+"state:\"In Progress\""
+
+# Stories with specific labels
+"label:bug !is:done"
+
+# Stories for specific team
+"team:\"Engineering Team\""
+
+# Stories in current iteration
+"iteration:current"
+```
+
+### Time-based Queries
+
+```ruby
+# Stories created this week
+"created:>-7d"
+
+# Stories updated today
+"updated:>-1d"
+
+# Stories completed this month
+"completed:>-30d"
+
+# Stories due soon
+"deadline:<7d"
+```
+
+### Priority and Estimation
+
+```ruby
+# High priority stories
+"priority:high !is:done"
+
+# Stories without points
+"!has:points !is:done"
+
+# Stories with specific point values
+"points:3 !is:done"
+
+# Unassigned stories
+"!has:owner !is:done"
+```
+
+## Example Configurations
+
+### Personal Dashboard
+
+```ruby
+# My active work
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "My Active Stories"
+  pane.interval = 180
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "owner:me state:\"In Progress\""
+  )
+end
+
+# My backlog
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0.5
+  
+  pane.title = "My Backlog"
+  pane.interval = 300
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "owner:me state:\"Ready for Development\""
+  )
+end
+
+# Stories waiting for review
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0.5
+  pane.left = 0
+  
+  pane.title = "Waiting for Review"
+  pane.interval = 120
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "owner:me state:\"In Review\""
+  )
+end
+```
+
+### Team Dashboard
+
+```ruby
+# Team overview with multiple pages
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Team Overview"
+  pane.interval = 300
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query_pages: {
+      "In Progress" => "team:\"Engineering\" state:\"In Progress\"",
+      "In Review" => "team:\"Engineering\" state:\"In Review\"",
+      "Blocked" => "team:\"Engineering\" label:blocked !is:done",
+      "Ready" => "team:\"Engineering\" state:\"Ready for Development\"",
+      "Bugs" => "team:\"Engineering\" type:bug !is:done"
+    }
+  )
+end
+```
+
+### Sprint/Iteration Monitoring
+
+```ruby
+# Current iteration
+add_pane do |pane|
+  pane.height = 0.4
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Current Sprint"
+  pane.interval = 180
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "iteration:current"
+  )
+end
+
+# Upcoming iteration
+add_pane do |pane|
+  pane.height = 0.3
+  pane.width = 1.0
+  pane.top = 0.4
+  pane.left = 0
+  
+  pane.title = "Next Sprint"
+  pane.interval = 600
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "iteration:next"
+  )
+end
+
+# Recently completed
+add_pane do |pane|
+  pane.height = 0.3
+  pane.width = 1.0
+  pane.top = 0.7
+  pane.left = 0
+  
+  pane.title = "Recently Completed"
+  pane.interval = 3600
+  
+  pane.type = Wassup::Panes::Shortcut::Stories.new(
+    query: "completed:>-7d"
+  )
+end
+```
+
+## Understanding Story Data
+
+### Story Types
+
+- **Feature** - New functionality
+- **Bug** - Issues to fix
+- **Chore** - Maintenance tasks
+- **Epic** - Large features broken into smaller stories
+
+### Workflow States
+
+Shortcut allows custom workflow states, but common ones include:
+- **Unscheduled** - Not yet planned
+- **Ready for Development** - Ready to be worked on
+- **In Progress** - Currently being worked on
+- **In Review** - Under review/testing
+- **Done** - Completed
+
+### Story Points
+
+- Used for estimation and planning
+- Typically follow Fibonacci sequence (1, 2, 3, 5, 8, 13, 21)
+- Help with sprint planning and capacity management
+
+## Rate Limiting
+
+Shortcut API has rate limits:
+- 200 requests per minute for most endpoints
+- Higher limits for premium accounts
+
+The pane automatically handles rate limiting and will show appropriate messages when limits are reached.
+
+## Troubleshooting
+
+### Authentication Issues
+
+If you're getting authentication errors:
+
+1. Verify your Shortcut API token is set correctly:
+   ```bash
+   echo $SHORTCUT_API_TOKEN
+   ```
+2. Check that the token has the correct permissions
+3. Ensure the token hasn't expired or been revoked
+
+### No Stories Showing
+
+If no stories are displayed:
+
+1. Verify your search query is correct
+2. Check that stories matching your query exist
+3. Ensure your account has access to the stories
+4. Test the query in Shortcut's web interface first
+
+### Common Issues
+
+**Query syntax errors:**
+- Check Shortcut's search documentation for proper syntax
+- Test queries in the Shortcut web interface before using in Wassup
+- Common syntax: `field:value`, `!field:value` (not), `field:>value` (greater than)
+
+**Permission errors:**
+- Verify your API token has access to the workspace
+- Check if stories are in projects you don't have access to
+
+**Performance issues:**
+- Consider using more specific queries to reduce result sets
+- Increase intervals for less critical queries
+- Monitor API usage to avoid rate limits
+
+## Advanced Query Examples
+
+### Complex Conditions
+
+```ruby
+# Stories assigned to me or my team, not done, high priority
+"(owner:me OR team:\"My Team\") !is:done priority:high"
+
+# Bugs created in the last week without owners
+"type:bug created:>-7d !has:owner"
+
+# Stories in specific project with points
+"project:\"Mobile App\" has:points !is:done"
+```
+
+### Date Ranges
+
+```ruby
+# Stories created between specific dates
+"created:2023-01-01..2023-01-31"
+
+# Stories updated in the last 3 days
+"updated:>-3d"
+
+# Stories with deadlines this month
+"deadline:2023-01-01..2023-01-31"
+```
+
+For more information about Shortcut integration and query syntax, see the [Shortcut API documentation](https://shortcut.com/api/rest/v3) or check the [Common Issues Guide](../troubleshooting/common-issues.md).

--- a/docs/docs/panes/world-clock.md
+++ b/docs/docs/panes/world-clock.md
@@ -1,0 +1,422 @@
+# World Clock Pane
+
+The World Clock pane allows you to display multiple time zones in your Wassup dashboard. Perfect for distributed teams, it shows current times across different locations with optional color coding for working hours.
+
+## Features
+
+- **Multiple timezone support** - Display any number of locations
+- **Working hours color coding** - Visual indicators for collaboration timing
+- **Flexible configuration** - Customizable time/date formats and working hours
+- **Smart timezone handling** - Uses system TZ support with DST awareness
+- **Sorting options** - alphabetical, chronological, reverse chronological, natural
+
+## Basic Configuration
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "World Clock"
+  pane.interval = 60  # Update every minute
+  
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "New York" => "America/New_York",
+      "London" => "Europe/London",
+      "Tokyo" => "Asia/Tokyo"
+    }
+  )
+end
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `locations` | Hash | `{}` | Map of display names to timezone identifiers |
+| `sort_order` | String | `"natural"` | Sort order: "alphabetical", "chronological", "reversechronological", "natural" |
+| `time_format` | String | `"%H:%M:%S"` | Time display format (Ruby strftime) |
+| `date_format` | String | `"%Y-%m-%d"` | Date display format (Ruby strftime) |
+| `working_hours` | Hash | `{start: 9, end: 17}` | Working hours definition |
+| `color_coding` | Boolean | `true` | Enable/disable working hours color coding |
+
+## Timezone Formats
+
+The World Clock pane supports multiple timezone formats:
+
+### TZ Database Names (Recommended)
+
+```ruby
+locations: {
+  "New York" => "America/New_York",
+  "Los Angeles" => "America/Los_Angeles",
+  "Chicago" => "America/Chicago",
+  "London" => "Europe/London",
+  "Paris" => "Europe/Paris",
+  "Berlin" => "Europe/Berlin",
+  "Madrid" => "Europe/Madrid",
+  "Warsaw" => "Europe/Warsaw",
+  "Tokyo" => "Asia/Tokyo",
+  "Dubai" => "Asia/Dubai",
+  "Sydney" => "Australia/Sydney",
+  "Montevideo" => "America/Montevideo"
+}
+```
+
+### UTC Offsets
+
+```ruby
+locations: {
+  "UTC" => "UTC",
+  "GMT+1" => "+01:00",
+  "GMT-5" => "-05:00",
+  "Singapore" => "+08:00"
+}
+```
+
+## Working Hours Color Coding
+
+The World Clock pane can color-code times based on working hours:
+
+- 🟢 **Green** - Core working hours
+- 🟡 **Yellow** - Transition hours (1 hour before/after work)
+- 🔴 **Red** - Outside working hours
+
+### Color Coding Configuration
+
+```ruby
+pane.type = Wassup::Panes::WorldClock.new(
+  locations: {
+    "Me" => "America/Chicago",
+    "Dan" => "America/New_York",
+    "Franco" => "America/Montevideo",
+    "Barbara" => "Europe/Madrid",
+    "Marek" => "Europe/Warsaw"
+  },
+  working_hours: {start: 9, end: 17},  # 9 AM to 5 PM
+  color_coding: true
+)
+```
+
+### Custom Working Hours
+
+```ruby
+# Early bird schedule
+working_hours: {start: 7, end: 15}  # 7 AM to 3 PM
+
+# Standard business hours
+working_hours: {start: 9, end: 17}  # 9 AM to 5 PM
+
+# Extended hours
+working_hours: {start: 8, end: 18}  # 8 AM to 6 PM
+
+# Evening shift
+working_hours: {start: 14, end: 22}  # 2 PM to 10 PM
+```
+
+## Sorting Options
+
+### Alphabetical
+
+Sort locations alphabetically by name:
+
+```ruby
+sort_order: "alphabetical"
+```
+
+### Chronological
+
+Sort by current time (earliest to latest):
+
+```ruby
+sort_order: "chronological"
+```
+
+### Reverse Chronological
+
+Sort by current time (latest to earliest):
+
+```ruby
+sort_order: "reversechronological"
+```
+
+### Natural
+
+Keep the original order specified in the configuration:
+
+```ruby
+sort_order: "natural"
+```
+
+## Time and Date Formatting
+
+### Common Time Formats
+
+```ruby
+# 24-hour format
+time_format: "%H:%M:%S"    # 14:30:45
+time_format: "%H:%M"       # 14:30
+
+# 12-hour format
+time_format: "%I:%M %p"    # 02:30 PM
+time_format: "%I:%M%p"     # 02:30PM
+time_format: "%l:%M %p"    # 2:30 PM (no leading zero)
+```
+
+### Common Date Formats
+
+```ruby
+# ISO format
+date_format: "%Y-%m-%d"    # 2023-12-25
+
+# US format
+date_format: "%m/%d/%Y"    # 12/25/2023
+
+# Abbreviated with day
+date_format: "%a %b %d"    # Mon Dec 25
+
+# Full date
+date_format: "%A, %B %d, %Y"  # Monday, December 25, 2023
+```
+
+## Example Configurations
+
+### Team Coordination Dashboard
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Team Time Zones"
+  pane.interval = 60
+  
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "Josh (Chicago)" => "America/Chicago",
+      "Dan (New York)" => "America/New_York",
+      "Franco (Montevideo)" => "America/Montevideo",
+      "Barbara (Madrid)" => "Europe/Madrid",
+      "Marek (Warsaw)" => "Europe/Warsaw"
+    },
+    sort_order: "chronological",
+    time_format: "%I:%M%p",
+    date_format: "%a %b %d",
+    working_hours: {start: 9, end: 17},
+    color_coding: true
+  )
+end
+```
+
+### Global Office Hours
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.4
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Office Hours"
+  pane.interval = 300  # Update every 5 minutes
+  
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "San Francisco" => "America/Los_Angeles",
+      "New York" => "America/New_York",
+      "London" => "Europe/London",
+      "Singapore" => "+08:00"
+    },
+    sort_order: "alphabetical",
+    time_format: "%H:%M",
+    date_format: "%a",
+    working_hours: {start: 8, end: 18},
+    color_coding: true
+  )
+end
+```
+
+### Meeting Scheduler
+
+```ruby
+add_pane do |pane|
+  pane.height = 0.5
+  pane.width = 1.0
+  pane.top = 0.5
+  pane.left = 0
+  
+  pane.title = "Meeting Times"
+  pane.interval = 60
+  
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "West Coast" => "America/Los_Angeles",
+      "East Coast" => "America/New_York",
+      "London" => "Europe/London",
+      "Central Europe" => "Europe/Berlin",
+      "India" => "Asia/Kolkata",
+      "Australia" => "Australia/Sydney"
+    },
+    sort_order: "chronological",
+    time_format: "%I:%M %p",
+    date_format: "%a %b %d",
+    working_hours: {start: 9, end: 17},
+    color_coding: true
+  )
+end
+```
+
+## Advanced Features
+
+### Daylight Saving Time (DST)
+
+The World Clock pane automatically handles DST transitions for supported timezones:
+
+- **US/Canada** - Second Sunday in March to first Sunday in November
+- **Europe** - Last Sunday in March to last Sunday in October  
+- **Australia** - First Sunday in October to first Sunday in April
+
+### Multiple Panes for Different Contexts
+
+```ruby
+# Personal contacts
+add_pane do |pane|
+  pane.height = 0.33
+  pane.width = 1.0
+  pane.top = 0
+  pane.left = 0
+  
+  pane.title = "Family & Friends"
+  pane.interval = 300
+  
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "Mom (Phoenix)" => "America/Phoenix",
+      "Sister (London)" => "Europe/London",
+      "Friend (Tokyo)" => "Asia/Tokyo"
+    },
+    sort_order: "alphabetical",
+    working_hours: {start: 8, end: 22},  # Extended hours for personal
+    color_coding: true
+  )
+end
+
+# Work contacts
+add_pane do |pane|
+  pane.height = 0.33
+  pane.width = 1.0
+  pane.top = 0.33
+  pane.left = 0
+  
+  pane.title = "Work Team"
+  pane.interval = 180
+  
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "Office (SF)" => "America/Los_Angeles",
+      "Remote (NYC)" => "America/New_York",
+      "Remote (Berlin)" => "Europe/Berlin"
+    },
+    sort_order: "chronological",
+    working_hours: {start: 9, end: 17},
+    color_coding: true
+  )
+end
+
+# Client locations
+add_pane do |pane|
+  pane.height = 0.34
+  pane.width = 1.0
+  pane.top = 0.66
+  pane.left = 0
+  
+  pane.title = "Client Locations"
+  pane.interval = 600
+  
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "Client A (Dubai)" => "Asia/Dubai",
+      "Client B (Sydney)" => "Australia/Sydney",
+      "Client C (São Paulo)" => "America/Sao_Paulo"
+    },
+    sort_order: "alphabetical",
+    working_hours: {start: 8, end: 18},
+    color_coding: true
+  )
+end
+```
+
+## Best Practices
+
+### Refresh Intervals
+
+- **60 seconds** - For active coordination (recommended)
+- **300 seconds** - For general awareness
+- **600 seconds** - For reference information
+
+### Location Naming
+
+Use descriptive names that provide context:
+
+```ruby
+# Good - includes person/role context
+"Josh (Product)" => "America/Chicago"
+"Remote Dev Team" => "Europe/London"
+"Client (APAC)" => "Asia/Singapore"
+
+# Less helpful - generic names
+"Chicago" => "America/Chicago"
+"London" => "Europe/London"
+"Singapore" => "Asia/Singapore"
+```
+
+### Working Hours Configuration
+
+Consider different working hour patterns for different contexts:
+
+```ruby
+# Standard business hours
+working_hours: {start: 9, end: 17}
+
+# Development team (may work later)
+working_hours: {start: 10, end: 18}
+
+# Customer support (extended hours)
+working_hours: {start: 7, end: 19}
+
+# Personal contacts (more flexible)
+working_hours: {start: 8, end: 22}
+```
+
+## Troubleshooting
+
+### Timezone Issues
+
+If times appear incorrect:
+
+1. Verify timezone identifiers are correct
+2. Check if DST is being handled properly
+3. Ensure system timezone data is up to date
+
+### Performance
+
+For better performance:
+
+- Use longer intervals for less critical information
+- Limit the number of locations to avoid clutter
+- Consider splitting into multiple panes for different contexts
+
+### Display Issues
+
+If the display looks wrong:
+
+- Check terminal size and pane dimensions
+- Verify time/date format strings are valid
+- Ensure location names aren't too long for the display
+
+For more troubleshooting help, see the [Common Issues Guide](../troubleshooting/common-issues.md).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -40,6 +40,18 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Prebuilt Panes',
+      items: [
+        'panes/overview',
+        'panes/github',
+        'panes/circleci',
+        'panes/netlify',
+        'panes/shortcut',
+        'panes/world-clock',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Integrations',
       items: [
         'integrations/github',

--- a/examples/world_clock/Supfile
+++ b/examples/world_clock/Supfile
@@ -1,0 +1,53 @@
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0
+
+  pane.highlight = false
+  pane.title = "World Clock"
+  pane.interval = 60  # Update every minute
+
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "New York" => "America/New_York",
+      "London" => "Europe/London", 
+      "Tokyo" => "Asia/Tokyo",
+      "Sydney" => "Australia/Sydney",
+      "Dubai" => "Asia/Dubai",
+      "UTC" => "UTC"
+    },
+    sort_order: "alphabetical",
+    time_format: "%H:%M:%S",
+    date_format: "%Y-%m-%d",
+    working_hours: {start: 9, end: 17},
+    color_coding: true
+  )
+end
+
+add_pane do |pane|
+  pane.height = 0.6
+  pane.width = 0.5
+  pane.top = 0
+  pane.left = 0.5
+
+  pane.highlight = false
+  pane.title = "Business Hours"
+  pane.interval = 60  # Update every minute
+
+  pane.type = Wassup::Panes::WorldClock.new(
+    locations: {
+      "San Francisco" => "America/Los_Angeles",
+      "Chicago" => "America/Chicago",
+      "New York" => "America/New_York",
+      "London" => "Europe/London",
+      "Paris" => "Europe/Paris",
+      "Singapore" => "+08:00"
+    },
+    sort_order: "chronological",
+    time_format: "%H:%M",
+    date_format: "%a %b %d",
+    working_hours: {start: 8, end: 18},
+    color_coding: true
+  )
+end

--- a/lib/wassup.rb
+++ b/lib/wassup.rb
@@ -13,6 +13,7 @@ require "wassup/panes/circleci"
 require "wassup/panes/github"
 require "wassup/panes/netlify"
 require "wassup/panes/shortcut"
+require "wassup/panes/world_clock"
 
 module Wassup
   class Error < StandardError; end

--- a/lib/wassup/panes/world_clock.rb
+++ b/lib/wassup/panes/world_clock.rb
@@ -1,0 +1,239 @@
+require 'time'
+
+module Wassup
+  module Panes
+    class WorldClock
+      attr_accessor :locations
+      attr_accessor :sort_order
+      attr_accessor :date_format
+      attr_accessor :time_format
+      attr_accessor :working_hours
+      attr_accessor :color_coding
+
+      def initialize(locations: {}, sort_order: 'natural', date_format: '%Y-%m-%d', time_format: '%H:%M:%S', working_hours: {start: 9, end: 17}, color_coding: true)
+        @locations = locations
+        @sort_order = sort_order
+        @date_format = date_format
+        @time_format = time_format
+        @working_hours = working_hours
+        @color_coding = color_coding
+      end
+
+      def configure(pane)
+        pane.content do |content|
+          now = Time.now
+          
+          # Build timezone data
+          timezone_data = locations.map do |name, timezone|
+            begin
+              # Parse timezone and get current time
+              tz_time = get_timezone_time(now, timezone)
+              {
+                name: name,
+                timezone: timezone,
+                time: tz_time,
+                display_time: format_time_with_color(tz_time, tz_time.strftime(time_format)),
+                display_date: tz_time.strftime(date_format)
+              }
+            rescue => e
+              {
+                name: name,
+                timezone: timezone,
+                time: nil,
+                display_time: "[fg=red]Invalid TZ[fg=white]",
+                display_date: "[fg=red]---[fg=white]"
+              }
+            end
+          end
+
+          # Sort according to sort_order
+          case sort_order
+          when 'alphabetical'
+            timezone_data.sort_by! { |tz| tz[:name] }
+          when 'chronological'
+            timezone_data.sort_by! { |tz| tz[:time] || Time.at(0) }
+          when 'reversechronological'
+            timezone_data.sort_by! { |tz| tz[:time] || Time.at(0) }.reverse!
+          when 'natural'
+            # Keep original order
+          end
+
+          # Add header
+          content.add_row("[fg=cyan]Location[fg=white]                  [fg=cyan]Time[fg=white]        [fg=cyan]Date[fg=white]")
+          content.add_row("─" * 50)
+
+          # Add timezone rows
+          timezone_data.each do |tz|
+            location_padded = tz[:name].ljust(20)
+            time_padded = tz[:display_time].ljust(10)
+            
+            display_line = "#{location_padded} #{time_padded} #{tz[:display_date]}"
+            content.add_row(display_line, tz)
+          end
+
+          # Add current refresh time
+          content.add_row("")
+          content.add_row("[fg=gray]Last updated: #{now.strftime('%H:%M:%S')}[fg=white]")
+        end
+      end
+
+      private
+
+      def get_work_hours_color(time)
+        return 'white' unless color_coding
+        
+        hour = time.hour
+        start_hour = working_hours[:start] || 9
+        end_hour = working_hours[:end] || 17
+        
+        # Define transition zones (1 hour before/after work hours)
+        pre_work_warning = start_hour - 1
+        post_work_warning = end_hour + 1
+        
+        case hour
+        when start_hour...end_hour
+          # Core working hours - green
+          'green'
+        when pre_work_warning, post_work_warning
+          # Close to start/end - yellow
+          'yellow'
+        else
+          # Outside working hours - red
+          'red'
+        end
+      end
+
+      def format_time_with_color(time, formatted_time)
+        return formatted_time unless color_coding
+        
+        color = get_work_hours_color(time)
+        "[fg=#{color}]#{formatted_time}[fg=white]"
+      end
+
+      def get_timezone_time(base_time, timezone)
+        # Try to use system timezone support first
+        if timezone.match?(/^[A-Z][a-z]+\/[A-Z][a-z_]+/)
+          # This is a TZ database name like "America/New_York"
+          begin
+            # Use Ruby's built-in timezone handling with ENV
+            original_tz = ENV['TZ']
+            ENV['TZ'] = timezone
+            result = Time.at(base_time.to_i).localtime
+            ENV['TZ'] = original_tz
+            return result
+          rescue
+            # Fall back to offset calculation
+            return base_time.getlocal(timezone_offset(timezone))
+          end
+        else
+          # Handle offset format like "+01:00" or "-05:00"
+          return base_time.getlocal(timezone_offset(timezone))
+        end
+      end
+
+      def timezone_offset(timezone)
+        # Handle common timezone formats
+        case timezone
+        when /^UTC$/i, /^GMT$/i
+          '+00:00'
+        when /^America\/New_York$/i
+          # Eastern Time (UTC-5 or UTC-4 with DST)
+          dst_active?(timezone) ? '-04:00' : '-05:00'
+        when /^America\/Chicago$/i
+          # Central Time (UTC-6 or UTC-5 with DST)
+          dst_active?(timezone) ? '-05:00' : '-06:00'
+        when /^America\/Denver$/i
+          # Mountain Time (UTC-7 or UTC-6 with DST)
+          dst_active?(timezone) ? '-06:00' : '-07:00'
+        when /^America\/Los_Angeles$/i
+          # Pacific Time (UTC-8 or UTC-7 with DST)
+          dst_active?(timezone) ? '-07:00' : '-08:00'
+        when /^Europe\/London$/i
+          # GMT/BST (UTC+0 or UTC+1 with DST)
+          dst_active?(timezone) ? '+01:00' : '+00:00'
+        when /^Europe\/Paris$/i, /^Europe\/Berlin$/i, /^Europe\/Madrid$/i, /^Europe\/Warsaw$/i
+          # Central European Time (UTC+1 or UTC+2 with DST)
+          dst_active?(timezone) ? '+02:00' : '+01:00'
+        when /^America\/Montevideo$/i
+          # Uruguay Time (UTC-3, no DST currently)
+          '-03:00'
+        when /^Asia\/Tokyo$/i
+          '+09:00'
+        when /^Asia\/Dubai$/i
+          '+04:00'
+        when /^Asia\/Shanghai$/i
+          '+08:00'
+        when /^Australia\/Sydney$/i
+          # AEST/AEDT (UTC+10 or UTC+11 with DST)
+          dst_active?(timezone) ? '+11:00' : '+10:00'
+        when /^[+-]\d{2}:\d{2}$/
+          # Already in offset format
+          timezone
+        else
+          # Try to parse as offset or default to UTC
+          begin
+            Time.parse("2000-01-01 12:00:00 #{timezone}").strftime('%z')
+          rescue
+            '+00:00'
+          end
+        end
+      end
+
+      def dst_active?(timezone)
+        # Simplified DST detection - in a real implementation, 
+        # you'd want to use a proper timezone library
+        now = Time.now
+        case timezone
+        when /^America\//
+          # US DST: second Sunday in March to first Sunday in November
+          march_dst_start = second_sunday_of_march(now.year)
+          november_dst_end = first_sunday_of_november(now.year)
+          now >= march_dst_start && now < november_dst_end
+        when /^Europe\//
+          # EU DST: last Sunday in March to last Sunday in October
+          march_dst_start = last_sunday_of_march(now.year)
+          october_dst_end = last_sunday_of_october(now.year)
+          now >= march_dst_start && now < october_dst_end
+        when /^Australia\/Sydney$/
+          # Australia DST: first Sunday in October to first Sunday in April
+          october_dst_start = first_sunday_of_october(now.year)
+          april_dst_end = first_sunday_of_april(now.year + 1)
+          now >= october_dst_start || now < april_dst_end
+        else
+          false
+        end
+      end
+
+      def second_sunday_of_march(year)
+        march_1 = Time.new(year, 3, 1)
+        first_sunday = march_1 + (7 - march_1.wday) % 7
+        first_sunday + 7
+      end
+
+      def first_sunday_of_november(year)
+        november_1 = Time.new(year, 11, 1)
+        november_1 + (7 - november_1.wday) % 7
+      end
+
+      def last_sunday_of_march(year)
+        march_31 = Time.new(year, 3, 31)
+        march_31 - march_31.wday
+      end
+
+      def last_sunday_of_october(year)
+        october_31 = Time.new(year, 10, 31)
+        october_31 - october_31.wday
+      end
+
+      def first_sunday_of_october(year)
+        october_1 = Time.new(year, 10, 1)
+        october_1 + (7 - october_1.wday) % 7
+      end
+
+      def first_sunday_of_april(year)
+        april_1 = Time.new(year, 4, 1)
+        april_1 + (7 - april_1.wday) % 7
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
• Add WorldClock pane module for displaying multiple timezones with working hours color coding
• Support for TZ database names (e.g., "America/New_York") and UTC offsets (e.g., "+08:00")
• Color-coded times based on working hours: green (work hours), yellow (transition), red (off hours)
• Configurable working hours, display formats, and sorting options

## Features
• **Multiple timezone support** - Display any number of locations
• **Working hours color coding** - Visual indicators for collaboration timing
• **Flexible configuration** - Customizable time/date formats and working hours
• **Smart timezone handling** - Uses system TZ support with DST awareness
• **Sorting options** - alphabetical, chronological, reverse chronological, natural

## Test plan
- [x] Test basic world clock functionality with multiple timezones
- [x] Verify color coding works correctly for different time ranges
- [x] Test DST handling for various timezone combinations
- [x] Validate configuration options and error handling
- [x] Test example configuration files

🤖 Generated with [Claude Code](https://claude.ai/code)